### PR TITLE
Update with support for template aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-postmark",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "description": "Send emails through Postmark using GruntJS",
   "main": "Gruntfile.js",
   "homepage": "https://github.com/wildbit/grunt-postmark.git",

--- a/tasks/grunt-postmark-templates.js
+++ b/tasks/grunt-postmark-templates.js
@@ -79,9 +79,7 @@ module.exports = function (grunt) {
           grunt.log.warn('Template ' + templateIdentifier + ' not found, so attempting create');
           delete template.templateId;
           delete expanded.TemplateId;
-          delete template.templateAlias;
-          delete expanded.TemplateAlias;
-          client.createTemplate(templateIdentifier, function (err, response) {
+          client.createTemplate(expanded, function (err, response) {
             grunt.log.writeln('Template ' + expanded.Name + ' created: ' + printResponse(response));
             handleResponse(err, done, response, template, ephemeralUploadResultsProperty);
           });


### PR DESCRIPTION
I want to use the feature to upload my templates by aliases instead of ids. For testing purposes I'm using two different Postmark servers to first upload my templates to the "staging server" and then to the "production server". Using aliases made it a lot easier to do so.